### PR TITLE
método: dado una id de test realizado devuelve una estructura del test

### DIFF
--- a/duocoding/src/main/java/com/codingtrainers/duocoding/repositories/TestExecutionResponseRepository.java
+++ b/duocoding/src/main/java/com/codingtrainers/duocoding/repositories/TestExecutionResponseRepository.java
@@ -19,4 +19,6 @@ public interface TestExecutionResponseRepository extends CrudRepository<TestExec
     Optional<TestExecutionResponse> findByTestExecutionAndQuestion(TestExecution testExecution, Question question);
 
     void deleteByTestExecution(TestExecution testExecution);
+
+    List<TestExecutionResponse> findByTestExecutionId(Long testExecutionId);
 }


### PR DESCRIPTION
Este PR agrega un nuevo método en `TestExecutionService` que permite obtener la estructura completa de un test realizado por su ID. Incluye las preguntas, respuestas del usuario, respuestas disponibles.
